### PR TITLE
Added new DNSSEC trust anchor for KSK rollover

### DIFF
--- a/external/unbound/smallapp/unbound-anchor.c
+++ b/external/unbound/smallapp/unbound-anchor.c
@@ -236,11 +236,16 @@ get_builtin_cert(void)
 }
 
 /** return the built in root DS trust anchor */
-static const char*
+static const char* const*
 get_builtin_ds(void)
 {
-	return
-". IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n";
+  static const char * const ds[] =
+  {
+    ". IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n",
+    ". IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D\n",
+    NULL
+  };
+  return ds;
 }
 
 /** print hex data */


### PR DESCRIPTION
More info about the rollover can be found here: https://www.icann.org/resources/pages/ksk-rollover